### PR TITLE
Use never to assure every event type is categorized

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Continuous Integration
 
 on:
   # Trigger the workflow on push or pull request,
@@ -11,8 +11,8 @@ on:
       - main
 
 jobs:
-  run-linters:
-    name: Run linters
+  build-lint-test:
+    name: Build, Lint, Test
     runs-on: ubuntu-latest
 
     steps:
@@ -30,3 +30,9 @@ jobs:
 
       - name: Run linters
         run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "build.watch": "concurrently \"npm run build.extension.watch\" \"npm run build.webview.watch\"",
     "format": "prettier --write .",
     "lint": "eslint src --ext .ts --no-error-on-unmatched-pattern && prettier --end-of-line auto --check .",
-    "test": "TS_NODE_PROJECT=./webview/tsconfig.json mocha -r ts-node/register"
+    "test": "TS_NODE_PROJECT=./webview/tsconfig.json mocha \"webview/src/**/*.spec.ts\" -r ts-node/register"
   },
   "dependencies": {
     "@temporalio/client": "^1.5.2",

--- a/webview/src/utilities/get-workflow-tasks.ts
+++ b/webview/src/utilities/get-workflow-tasks.ts
@@ -47,6 +47,8 @@ function categorizeEvent(eventType: EventType): Category {
     case EventType.EVENT_TYPE_MARKER_RECORDED:
     case EventType.EVENT_TYPE_TIMER_CANCELED:
     case EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES:
+    case EventType.EVENT_TYPE_WORKFLOW_UPDATE_ACCEPTED:
+    case EventType.EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED:
       return "COMMAND"
     // Completions and other non-command events go here
     case EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:
@@ -68,13 +70,11 @@ function categorizeEvent(eventType: EventType): Category {
     case EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED:
     case EventType.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
     case EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
+    case EventType.EVENT_TYPE_WORKFLOW_UPDATE_REQUESTED:
+    case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED:
+    case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY:
+    case EventType.EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY:
       return "EVENT"
-    // TODO: add these when protos are updated
-    // case EventType.EVENT_TYPE_WORKFLOW_UPDATE_REQUESTED:
-    // case EventType.EVENT_TYPE_WORKFLOW_UPDATE_ACCEPTED:
-    // case EventType.EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED:
-    // case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY:
-    // case EventType.EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY:
     default:
       unhandledEventType(eventType)
   }

--- a/webview/src/utilities/get-workflow-tasks.ts
+++ b/webview/src/utilities/get-workflow-tasks.ts
@@ -14,9 +14,8 @@ type Category =
 
 /**
  * Map an event type to a category.
- * This function is used to verify any new events are categorized and explictly does not specify a "default" branch.
  */
-function categorizeEvent(eventType: EventType | undefined): Category {
+function categorizeEvent(eventType: EventType): Category {
   switch (eventType) {
     // Ignore these for display purposes, we'll show this a status in the title
     case EventType.EVENT_TYPE_UNSPECIFIED:
@@ -76,7 +75,14 @@ function categorizeEvent(eventType: EventType | undefined): Category {
     // case EventType.EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED:
     // case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY:
     // case EventType.EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY:
+    default:
+      return unhandledEventType(eventType)
   }
+}
+
+function unhandledEventType(eventType: never): Category {
+  console.log("Uncategorized event type: " + eventType)
+  return "EVENT"
 }
 
 // Collecting workflow
@@ -92,8 +98,7 @@ export function getWorkflowTasks(history: temporal.api.history.v1.IHistory): Wor
     if (ev.eventType == null) {
       throw new TypeError("Got event with no type")
     }
-    // When new events are added categorizeEvent will return undefined
-    const category = categorizeEvent(ev.eventType) ?? "EVENT"
+    const category = categorizeEvent(ev.eventType)
     switch (category) {
       case "IGNORE":
         break

--- a/webview/src/utilities/get-workflow-tasks.ts
+++ b/webview/src/utilities/get-workflow-tasks.ts
@@ -76,13 +76,12 @@ function categorizeEvent(eventType: EventType): Category {
     // case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY:
     // case EventType.EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY:
     default:
-      return unhandledEventType(eventType)
+      unhandledEventType(eventType)
   }
 }
 
-function unhandledEventType(eventType: never): Category {
-  console.log("Uncategorized event type: " + eventType)
-  return "EVENT"
+function unhandledEventType(eventType: never): never {
+  throw new Error("Uncategorized event type: " + eventType)
 }
 
 // Collecting workflow

--- a/webview/src/utilities/get-workflow-tasks.ts
+++ b/webview/src/utilities/get-workflow-tasks.ts
@@ -49,6 +49,7 @@ function categorizeEvent(eventType: EventType): Category {
     case EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES:
     case EventType.EVENT_TYPE_WORKFLOW_UPDATE_ACCEPTED:
     case EventType.EVENT_TYPE_WORKFLOW_UPDATE_COMPLETED:
+    case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED:
       return "COMMAND"
     // Completions and other non-command events go here
     case EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:
@@ -71,17 +72,21 @@ function categorizeEvent(eventType: EventType): Category {
     case EventType.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
     case EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
     case EventType.EVENT_TYPE_WORKFLOW_UPDATE_REQUESTED:
-    case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED:
     case EventType.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY:
     case EventType.EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY:
       return "EVENT"
     default:
-      unhandledEventType(eventType)
+      return unhandledEventType(eventType)
   }
 }
 
-function unhandledEventType(eventType: never): never {
-  throw new Error("Uncategorized event type: " + eventType)
+/**
+ * Catch-all for uncategorized event types.
+ * Note that this function takes `never` which improves the error message when new enum variants are added.
+ */
+function unhandledEventType(eventType: never): Category {
+  console.error("Unhandled event type", eventType)
+  return "EVENT"
 }
 
 // Collecting workflow


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Added TypeScript `never` to assure every case is handled in the switch statement for `categorizeEvent`.
* Added additional available event type cases to `categorizeEvent`
* Add GitHub action for tests 

## Why?
<!-- Tell your future self why have you made these changes -->
Before, the compile time error for unhandled event types was ⬇️ 

![Screenshot 2023-02-28 at 12 34 27 PM](https://user-images.githubusercontent.com/15069288/221965825-42186cb5-c148-4ff3-b4bc-06b4e55802d8.png)

Now there is a default case (which is more intuitive) and the error lists which types are not accounted for ⬇️ 

<img width="1468" alt="Screenshot 2023-02-28 at 1 04 28 PM" src="https://user-images.githubusercontent.com/15069288/221966198-08df9b3e-ad1c-4712-ada8-86200976915a.png">

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested: n/a
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
